### PR TITLE
update the usage of utils.reactome_pathway_overlay in use case

### DIFF
--- a/notebooks/usecase10_pathway_overlay.ipynb
+++ b/notebooks/usecase10_pathway_overlay.ipynb
@@ -1009,7 +1009,7 @@
     "image_path = utils.reactome_pathway_overlay('R-HSA-1236978', df=dfObj['simplified_change'], analysis_token=None, open_browser=False, \n",
     "                         export_path=\"test.png\", image_format='png', display_col_idx=None, \n",
     "                         diagram_colors='Modern', overlay_colors='Standard', quality=10)\n",
-    "Image(image_path)"
+    "Image(image_path[1])"
    ]
   }
  ],


### PR DESCRIPTION
I am not sure if the usage of the `utils.reactome_pathway_overlay` function has been changed before, but it seems to me that the current usage of it in the notebook is wrong.

https://github.com/PayneLab/cptac/blob/cda3f75f459aaefcc0705a7239c78aca5f81bf4d/cptac/utils/pathway_utils.py#L517-L520
utils.reactome_pathway_overlay always return a tuple. Therefore, to display the pathway fetched, user needs to use `image_path[1]` rather than `image_path.` The variable name might be not ideal, though.